### PR TITLE
Am branch

### DIFF
--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step1_QCD.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step1_QCD.py
@@ -1,0 +1,252 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: SingleGammaPt35_pythia8_cfi --conditions auto:phase1_2017_realistic -n 10 --era Run2_2017 --eventcontent FEVTDEBUG --relval 9000,50 -s GEN,SIM --datatier GEN-SIM --beamspot Realistic25ns13TeVEarly2017Collision --geometry DB:Extended --fileout file:step1.root
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing('standard')
+'''
+options.register('maxEvents',
+                10,
+                VarParsing.multiplicity.singleton,
+                VarParsing.varType.int,
+                "Number of events")
+options.register('etmin',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "ET or E min depending on doFlatEnergy")
+options.register('etmax',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "ET or E max depending on doFlatEnergy")
+options.register('rmin',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "Radius min")
+options.register('rmax',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "Radius max")
+options.register('zmin',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "Z min")
+options.register('zmax',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.float,
+                "Zmax")
+options.register('np',
+                 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                "Number of Particles")
+'''
+options.register('nThr',
+                 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                "Number of threads")
+options.register('seedOffset',
+                 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Seed offset")
+'''
+options.register('doFlatEnergy',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "generate flat in energy, otherwise flat in pt")
+'''
+options.register('year',
+                 2021,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "year of data-taking")
+options.register('doDefaultECALtags',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "use default ECAL tags in GT, except for PFRH tag")
+options.parseArguments()
+print options
+
+#my_doFlatEnergy = cms.bool(False) if options.doFlatEnergy == 0 else cms.bool(True)
+
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process('SIM',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.GeometrySimDB_cff')  #UL2016 driver: process.load('Configuration.Geometry.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRun3RoundOptics25ns13TeVLowSigmaZ_cfi') #UL2016 driver: process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeV2016Collision_cfi') 
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet()
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('SingleGammaPt35_pythia8_cfi nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# in UL2016 driver: process.FEVTDEBUGoutput
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    # we add compression compared to UL2016 driver
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    # compression option added here as well
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('file:step1.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+# added compared to UL2016 driver:
+process.XMLFromDBSource.label = cms.string("Extended")
+
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2021_realistic_v5', '')
+
+# Override ECAL tags
+if options.doDefaultECALtags == 0:
+  print 'Will override following ECAL tags'
+  process.GlobalTag.toGet = cms.VPSet()
+  from override_ECAL_tags import override_tags
+  for rec,tag in override_tags[options.year].items():
+    process.GlobalTag.toGet.append( cms.PSet(record = cms.string(rec), tag = cms.string(tag) )   )
+    print rec,tag
+    #print process.GlobalTag.toGet[0]
+
+
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings', 
+            'pythia8CP5Settings', 
+            'processParameters'
+        ),
+        processParameters = cms.vstring(
+            'HardQCD:all = on', 
+            'PhaseSpace:pTHatMin = 15.', 
+            'PhaseSpace:pTHatMax = 3000.'
+        ),
+        pythia8CP5Settings = cms.vstring(
+            'Tune:pp 14', 
+            'Tune:ee 7', 
+            'MultipartonInteractions:ecmPow=0.03344', 
+            'MultipartonInteractions:bProfile=2', 
+            'MultipartonInteractions:pT0Ref=1.41', 
+            'MultipartonInteractions:coreRadius=0.7634', 
+            'MultipartonInteractions:coreFraction=0.63', 
+            'ColourReconnection:range=5.176', 
+            'SigmaTotal:zeroAXB=off', 
+            'SpaceShower:alphaSorder=2', 
+            'SpaceShower:alphaSvalue=0.118', 
+            'SigmaProcess:alphaSvalue=0.118', 
+            'SigmaProcess:alphaSorder=2', 
+            'MultipartonInteractions:alphaSvalue=0.118', 
+            'MultipartonInteractions:alphaSorder=2', 
+            'TimeShower:alphaSorder=2', 
+            'TimeShower:alphaSvalue=0.118', 
+            'SigmaTotal:mode = 0', 
+            'SigmaTotal:sigmaEl = 21.89', 
+            'SigmaTotal:sigmaTot = 100.309', 
+            'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118'
+        ),
+        pythia8CommonSettings = cms.vstring(
+            'Tune:preferLHAPDF = 2', 
+            'Main:timesAllowErrors = 10000', 
+            'Check:epTolErr = 0.01', 
+            'Beams:setProductionScalesFromLHEF = off', 
+            'SLHA:keepSM = on', 
+            'SLHA:minMassSM = 1000.', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tau0Max = 10', 
+            'ParticleDecays:allowPhotonRadiation = on'
+        )
+    ),
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(74310000.0),
+    filterEfficiency = cms.untracked.double(0.037),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    reweightGen = cms.PSet(
+        pTRef = cms.double(15.0),
+        power = cms.double(4.5)
+    )
+)
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput) # in UL2016 driver: process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step) #UL2016 driver: process.FEVTDEBUGoutput_step
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.generator)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(options.nThr)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+
+# set a different offset seed, if you run multiple jobs 
+process.RandomNumberGeneratorService.eventSeedOffset=cms.untracked.uint32(options.seedOffset)
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step2_noPU.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step2_noPU.py
@@ -107,7 +107,7 @@ process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 from Configuration.AlCa.GlobalTag import GlobalTag
 if options.year == 2021:
   process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mcRun3_2021_realistic_v3', '')
-elif options.year == 2021:
+elif options.year == 2023:
   process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mcRun3_2023_realistic_v3', '')
 
 # Override ECAL tags

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
@@ -295,7 +295,7 @@ if options.doRefPfrh == 0:
     EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_ringaveraged_{y}.txt".format(y=options.noiseCond))
 else: #no ringAvg for reference thrs
   EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_{y}.txt".format(y=options.noiseCond))
-  EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_{y}.txt".format(y=options.options.noiseCond))
+  EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_{y}.txt".format(y=options.noiseCond))
 
 
 ### set pfrh thresholds

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
@@ -49,6 +49,11 @@ options.register('doRingAverageEE',
                  VarParsing.multiplicity.singleton,
                  VarParsing.varType.int,
                 "use ring average for pfrh and seeding thresholds for EE")
+options.register('doSafetyMargin',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                "raise value of pfrh and seeding thrs of 10%")
 options.register('doPU',
                  0,
                  VarParsing.multiplicity.singleton,
@@ -278,8 +283,12 @@ process.myCond.PFRecHitFile =   EB_pfrhthr_file
 process.myCond.PFRecHitFileEE = EE_pfrhthr_file
 
 if options.doRefPfrh == 0:
-  process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMult/2.0)
-  process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMult/3.0)
+  if options.doSafetyMargin == 1:   
+    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMult/2.0)
+    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMult/3.0)
+  else:
+    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMult/2.2)
+    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMult/3.3)
 else: # use the reference values
   process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(1.0)
   process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(1.0)
@@ -287,8 +296,12 @@ else: # use the reference values
 ### set seeding thresholds
 process.myCond.producedEcalPFSeedingThresholds = cms.untracked.bool(True)
 if options.doRefSeed == 0:
-  process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMult/2.0) # PFRHs files are at 2sigma of the noise for |eta|<2.5
-  process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMult/3.0) #                3sigma of the noise for |eta|>2.5
+  if options.doSafetyMargin == 1:
+    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMult/2.0) # PFRHs files are at 2sigma of the noise for |eta|<2.5
+    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMult/3.0) #                3sigma of the noise for |eta|>2.5
+  else:
+    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMult/2.2) # PFRHs files are at 2sigma of the noise for |eta|<2.5
+    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMult/3.3) #                3sigma of the noise for |eta|>2.5
   process.myCond.PFSeedingFile =   EB_pfrhthr_file
   process.myCond.PFSeedingFileEE = EE_pfrhthr_file
 else: # use the reference values

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
@@ -24,16 +24,26 @@ options.register ("noiseCond",
                   VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.varType.int,          # string, int, or float
                   "noise conditions")
-options.register ("pfrhMult",
+options.register ("pfrhMultbelow2p5",
                   1.0, # default value
                   VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.varType.float,          # string, int, or float
-                  "multiplier of noise used for PFRH thresholds")
-options.register ("seedMult",
+                  "multiplier of noise used for PFRH thresholds for |eta|<2.5")
+options.register ("pfrhMultabove2p5",
+                  1.0, # default value
+                  VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.varType.float,          # string, int, or float
+                  "multiplier of noise used for PFRH thresholds for |eta|>2.5")
+options.register ("seedMultbelow2p5",
                   3.0, # default value
                   VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.varType.float,          # string, int, or float
-                  "multiplier of noise used for seeding threshold")
+                  "multiplier of noise used for seeding threshold for |eta|<2.5")
+options.register ("seedMultabove2p5",
+                  3.0, # default value
+                  VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.varType.float,          # string, int, or float
+                  "multiplier of noise used for seeding threshold for |eta|>2.5")
 options.register('doRefPfrh',
                  0,
                  VarParsing.multiplicity.singleton,
@@ -295,11 +305,11 @@ process.myCond.PFRecHitFileEE = EE_pfrhthr_file
 
 if options.doRefPfrh == 0:
   if options.doSafetyMargin == 1:   
-    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMult/2.0)
-    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMult/3.0)
+    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMultbelow2p5/2.0)
+    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMultabove2p5/3.0)
   else:
-    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMult/2.2)
-    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMult/3.3)
+    process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(options.pfrhMultbelow2p5/2.2)
+    process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(options.pfrhMultabove2p5/3.3)
 else: # use the reference values
   process.myCond.EcalPFRecHitThresholdNSigmas = cms.untracked.double(1.0)
   process.myCond.EcalPFRecHitThresholdNSigmasHEta = cms.untracked.double(1.0)
@@ -308,11 +318,11 @@ else: # use the reference values
 process.myCond.producedEcalPFSeedingThresholds = cms.untracked.bool(True)
 if options.doRefSeed == 0:
   if options.doSafetyMargin == 1:
-    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMult/2.0) # PFRHs files are at 2sigma of the noise for |eta|<2.5
-    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMult/3.0) #                3sigma of the noise for |eta|>2.5
+    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMultbelow2p5/2.0) # PFRHs files are at 2sigma of the noise for |eta|<2.5
+    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMultabove2p5/3.0) #                3sigma of the noise for |eta|>2.5
   else:
-    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMult/2.2) # PFRHs files are at 2sigma of the noise for |eta|<2.5
-    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMult/3.3) #                3sigma of the noise for |eta|>2.5
+    process.myCond.EcalPFSeedingThresholdNSigmas = cms.untracked.double(options.seedMultbelow2p5/2.2) # PFRHs files are at 2sigma of the noise for |eta|<2.5
+    process.myCond.EcalPFSeedingThresholdNSigmasHEta = cms.untracked.double(options.seedMultabove2p5/3.3) #                3sigma of the noise for |eta|>2.5
   process.myCond.PFSeedingFile =   EB_pfrhthr_file
   process.myCond.PFSeedingFileEE = EE_pfrhthr_file
 else: # use the reference values

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step3.py
@@ -19,6 +19,11 @@ options.register ("dominiaodfile",
                   VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.varType.int,          # string, int, or float
                   "want to produce miniAOD file?")
+options.register ("noiseCond",
+                  2023, # default value
+                  VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.varType.int,          # string, int, or float
+                  "noise conditions")
 options.register ("pfrhMult",
                   1.0, # default value
                   VarParsing.multiplicity.singleton, # singleton or list
@@ -267,15 +272,21 @@ process.myCond = EcalTrivialConditionRetriever.clone()
 process.es_prefer = cms.ESPrefer("EcalTrivialConditionRetriever","myCond")
 
 # choose file from which to load the thresholds
-if options.doRingAverageEB == 0:
-  EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_{y}.txt".format(y=options.year))
-else:
-  EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_ringaveraged_{y}.txt".format(y=options.year))
+if options.doRefPfrh == 0:
+  # load EB thrs file
+  if options.doRingAverageEB == 0:
+    EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_{y}.txt".format(y=options.noiseCond))
+  else:
+    EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_ringaveraged_{y}.txt".format(y=options.noiseCond))
+  # load EE thrs file
+  if options.doRingAverageEE == 0:
+    EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_{y}.txt".format(y=options.noiseCond))
+  else:
+    EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_ringaveraged_{y}.txt".format(y=options.noiseCond))
+else: #no ringAvg for reference thrs
+  EB_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EB_{y}.txt".format(y=options.noiseCond))
+  EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_{y}.txt".format(y=options.options.noiseCond))
 
-if options.doRingAverageEE == 0:
-  EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_{y}.txt".format(y=options.year))
-else:
-  EE_pfrhthr_file = cms.untracked.string("./data/noise/PFRecHitThresholds_EE_ringaveraged_{y}.txt".format(y=options.year))
 
 ### set pfrh thresholds
 process.myCond.producedEcalPFRecHitThresholds = cms.untracked.bool(True)

--- a/Dumpers/test/ECALproductionHelper/cmsDrivers/step4.py
+++ b/Dumpers/test/ECALproductionHelper/cmsDrivers/step4.py
@@ -1,0 +1,135 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step5 --conditions 106X_dataRun2_v15 --era Run2_2017 --eventcontent NANOAODSIM --filein root://cms-xrd-global.cern.ch//store/relval/CMSSW_10_6_0_pre4/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/PU25ns_106X_upgrade2018_realistic_v4-v1/10000/F466F220-316A-AF4E-B986-C1700BCB4F16.root -s NANO --datatier NANOAODSIM --geometry DB:Extended --io NanoFull_2018PU.io --python NanoFull_2018PU.py --no_exec --fileout file:NoPU.root
+
+
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing('standard')
+options.register('nThr',
+                 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                "Number of threads")
+options.register('year',
+                 2021,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "year of data-taking")
+options.register('doDefaultECALtags',
+                 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "use default ECAL tags in GT, except for PFRH tag")
+options.parseArguments()
+print options
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('NANO',Run3)
+
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('PhysicsTools.NanoAOD.nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+   input = cms.untracked.int32(options.maxEvents)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:step3.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+      SkipEvent = cms.untracked.vstring('ProductNotFound')  #so that the code still runs if product not found
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step4 nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step4.root'),
+    outputCommands = process.NANOAODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+if options.year == 2021:
+  process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mcRun3_2021_realistic_v3', '')
+elif options.year == 2023:
+  process.GlobalTag = GlobalTag(process.GlobalTag, '106X_mcRun3_2023_realistic_v3', '')
+else: 
+  raise RuntimeError('Global tag not set properly, check logic')
+
+
+# Override ECAL tags
+if options.doDefaultECALtags == 0:
+  print 'Will override following ECAL tags'
+  process.GlobalTag.toGet = cms.VPSet()
+  from override_ECAL_tags import override_tags
+  for rec,tag in override_tags[options.year].items():
+    process.GlobalTag.toGet.append( cms.PSet(record = cms.string(rec), tag = cms.string(tag) )   )
+    print rec,tag
+    #print process.GlobalTag.toGet[0]
+
+
+# Path and EndPath definitions
+process.nanoAOD_step = cms.Path(process.nanoSequenceMC)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODSIMoutput_step = cms.EndPath(process.NANOAODSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step,process.NANOAODSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(options.nThr)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.NanoAOD.nano_cff
+from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeMC 
+
+#call to customisation function nanoAOD_customizeMC imported from PhysicsTools.NanoAOD.nano_cff
+process = nanoAOD_customizeMC(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/Dumpers/test/ECALproductionHelper/prodHelper.py
+++ b/Dumpers/test/ECALproductionHelper/prodHelper.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
   if opt.ch != 'QCD':
     prodLabel='{c}_{e}_{g}_{d}_{pu}_noiseCond{nsc}_pfrh{pf}_seed{s}_{mr}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,nsc=opt.noisecond,pf=pfrhLabel,s=seedLabel,mr=safetyLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
   else:
-    prodLabel='{c}_{pu}_noiseCond{nsc}_pfrh{pf}_seed{s}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,noiseCond=opt.noisecond,pf=pfrhLabel,s=seedLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
+    prodLabel='{c}_{pu}_noiseCond{nsc}_pfrh{pf}_seed{s}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,nsc=opt.noisecond,pf=pfrhLabel,s=seedLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
   dopu = 1 if opt.pu=='wPU' else 0
   # force the noise conditions to be of 2021 for reference thresholds
   if opt.dorefpfrh and opt.dorefseed:

--- a/Dumpers/test/ECALproductionHelper/prodHelper.py
+++ b/Dumpers/test/ECALproductionHelper/prodHelper.py
@@ -31,6 +31,7 @@ def getOptions():
   parser.add_argument('--dorefseed', dest='dorefseed', help='use reference values for seeding thresholds', action='store_true', default=False)
   parser.add_argument('--doringavgEB', dest='doringavgEB', help='apply ring-averaged thresholds in EB', action='store_true', default=False)
   parser.add_argument('--doringavgEE', dest='doringavgEE', help='apply ring-averaged thresholds in EE', action='store_true', default=False)
+  parser.add_argument('--dosafetymargin', dest='dosafetymargin', help='raise values on pfrh and seeding thrs of 10%', action='store_true', default=False)
   parser.add_argument('--showersigmamult', type=float, dest='showersigmamult', help='how large do you want the shower sigma', default=1.)
   parser.add_argument('--maxsigmadist', type=float, dest='maxsigmadist', help='max RH-cl distance in PFClustering, in units of sigma, THIS OPTION CURRENTLY DOES NOTHING', default=10.)
   parser.add_argument('--doreco', dest='doreco', help='do step 3 (reconstruction) and later stages (if any) starting from an existing production', action='store_true', default=False)
@@ -70,13 +71,15 @@ if __name__ == "__main__":
   thrLabelEB = 'RingEB' if opt.doringavgEB else 'XtalEB' 
   thrLabelEE = 'RingEE' if opt.doringavgEE else 'XtalEE'
   thrLabel = thrLabelEB + thrLabelEE
+  safetyLabel = 'noMargin' if not opt.dosafetymargin else 'wMargin'
   if opt.ch != 'QCD':
-    prodLabel='{c}_{e}_{g}_{d}_{pu}_pfrh{pf}_seed{s}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,pf=pfrhLabel,s=seedLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
+    prodLabel='{c}_{e}_{g}_{d}_{pu}_pfrh{pf}_seed{s}_{mr}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,pf=pfrhLabel,s=seedLabel,mr=safetyLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
   else:
     prodLabel='{c}_{pu}_pfrh{pf}_seed{s}_thr{thr}_shs{shs}_maxd{md}_y{y}_{v}_n{n}'.format(c=opt.ch,e=etRange,g=opt.geo,d=opt.det,pu=opt.pu,pf=pfrhLabel,s=seedLabel,thr=thrLabel,shs=opt.showersigmamult,md=opt.maxsigmadist,y=opt.year,v=opt.ver,n=opt.nevts)
   dopu = 1 if opt.pu=='wPU' else 0
   doringavgEB = 1 if opt.doringavgEB else 0
   doringavgEE = 1 if opt.doringavgEE else 0
+  dosafetymargin = 1 if opt.dosafetymargin else 0
   dorefpfrh = 1 if opt.dorefpfrh else 0
   dorefseed = 1 if opt.dorefseed else 0
   if    (    opt.doringavgEB and not os.path.isfile('../../data/noise/PFRecHitThresholds_EB_ringaveraged_{}.txt'.format(opt.year))) \
@@ -243,7 +246,7 @@ if __name__ == "__main__":
   else:
     dorecofile=0
     dominiaodfile=1
-  step3_cmsRun = 'cmsRun {jo} dorecofile={reco} dominiaodfile={miniaod} pfrhMult={pfrhm} seedMult={sm} nThr={nt} doRefPfrh={drpf} doRefSeed={drsd} doPU={dp} doRingAverageEB={draeb} doRingAverageEE={draee} year={y} doDefaultECALtags={ddet} showerSigmaMult={shs} maxSigmaDist={md} maxEvents={n}'.format(jo=target_drivers[2], reco=dorecofile, miniaod=dominiaodfile, pfrhm=opt.pfrhmult, sm=opt.seedmult, nt=nthr, drpf=dorefpfrh, drsd=dorefseed, dp=dopu, draeb=doringavgEB, draee=doringavgEE, y=opt.year, ddet=dodefaultecaltags, shs=opt.showersigmamult, md=opt.maxsigmadist, n=nevtsjob)
+  step3_cmsRun = 'cmsRun {jo} dorecofile={reco} dominiaodfile={miniaod} pfrhMult={pfrhm} seedMult={sm} nThr={nt} doRefPfrh={drpf} doRefSeed={drsd} doSafetyMargin={mr} doPU={dp} doRingAverageEB={draeb} doRingAverageEE={draee} year={y} doDefaultECALtags={ddet} showerSigmaMult={shs} maxSigmaDist={md} maxEvents={n}'.format(jo=target_drivers[2], reco=dorecofile, miniaod=dominiaodfile, pfrhm=opt.pfrhmult, sm=opt.seedmult, nt=nthr, drpf=dorefpfrh, drsd=dorefseed, mr=dosafetymargin, dp=dopu, draeb=doringavgEB, draee=doringavgEE, y=opt.year, ddet=dodefaultecaltags, shs=opt.showersigmamult, md=opt.maxsigmadist, n=nevtsjob)
   cmsRuns = [step1_cmsRun, step2_cmsRun, step3_cmsRun]
   cmsRuns_add = [step1_cmsRun_add, step2_cmsRun_add, '']
   if opt.ch == 'QCD':

--- a/Dumpers/test/ECALproductionHelper/prodHelper.py
+++ b/Dumpers/test/ECALproductionHelper/prodHelper.py
@@ -27,7 +27,11 @@ def getOptions():
 
   parser.add_argument('--noisecond', type=int, dest='noisecond', help='which noise conditions do you want', default=2023)
   parser.add_argument('--pfrhmult', type=float, dest='pfrhmult', help='how many sigma of the noise to use for PFRH thresholds', default=1.)
+  parser.add_argument('--pfrhmultbelow2p5', type=float, dest='pfrhmultbelow2p5', help='sigma of the noise for PFRH thresholds for |eta|<2.5', default=0.)
+  parser.add_argument('--pfrhmultabove2p5', type=float, dest='pfrhmultabove2p5', help='sigma of the noise for PFRH thresholds for |eta|>2.5', default=0.)
   parser.add_argument('--seedmult', type=float, dest='seedmult', help='how many sigma of the noise to use for seeding thresholds', default=3.)
+  parser.add_argument('--seedmultbelow2p5', type=float, dest='seedmultbelow2p5', help='sigma of the noise for seeding thresholds for |eta|<2.5', default=0.)
+  parser.add_argument('--seedmultabove2p5', type=float, dest='seedmultabove2p5', help='sigma of the noise for seeding thresholds for |eta|>2.5', default=0.)
   parser.add_argument('--dorefpfrh', dest='dorefpfrh', help='use reference values for pfrh and gathering thresholds', action='store_true', default=False)
   parser.add_argument('--dorefseed', dest='dorefseed', help='use reference values for seeding thresholds', action='store_true', default=False)
   parser.add_argument('--doringavgEB', dest='doringavgEB', help='apply ring-averaged thresholds in EB', action='store_true', default=False)
@@ -67,8 +71,28 @@ if __name__ == "__main__":
   user = os.environ["USER"]
   evar = 'E' if opt.doflatenergy else 'Et'
   etRange='{}{}to{}GeV'.format(evar,opt.etmin,opt.etmax)
-  pfrhLabel= opt.pfrhmult if not opt.dorefpfrh else 'Ref'
-  seedLabel= opt.seedmult if not opt.dorefseed else 'Ref'
+  if opt.pfrhmultbelow2p5 == 0:
+    pfrhLabel= opt.pfrhmult if not opt.dorefpfrh else 'Ref'
+  else:
+    pfrhLabel = '{a}-{b}'.format(a=opt.pfrhmultbelow2p5, b=opt.pfrhmultabove2p5)
+  if opt.seedmultbelow2p5 == 0:
+    seedLabel= opt.seedmult if not opt.dorefseed else 'Ref'
+  else:
+    seedLabel = '{a}-{b}'.format(a=opt.seedmultbelow2p5, b=opt.seedmultabove2p5)
+  #in case different values below/above 2.5 are not set, use the value of pfhrmult everywhere
+  if opt.pfrhmultbelow2p5 == 0:
+    pfrhMultbelow2p5 = opt.pfrhmult
+    pfrhMultabove2p5 = opt.pfrhmult
+  else:
+    pfrhMultbelow2p5 = opt.pfrhmultbelow2p5
+    pfrhMultabove2p5 = opt.pfrhmultabove2p5
+  #in case different values below/above 2.5 are not set, use the value of seedmult everywhere
+  if opt.seedmultbelow2p5 == 0:
+    seedMultbelow2p5 = opt.seedmult
+    seedMultabove2p5 = opt.seedmult
+  else:
+    seedMultbelow2p5 = opt.seedmultbelow2p5
+    seedMultabove2p5 = opt.seedmultabove2p5
   thrLabelEB = 'RingEB' if opt.doringavgEB else 'XtalEB' 
   thrLabelEE = 'RingEE' if opt.doringavgEE else 'XtalEE'
   thrLabel = thrLabelEB + thrLabelEE
@@ -252,7 +276,7 @@ if __name__ == "__main__":
   else:
     dorecofile=0
     dominiaodfile=1
-  step3_cmsRun = 'cmsRun {jo} dorecofile={reco} dominiaodfile={miniaod} pfrhMult={pfrhm} seedMult={sm} nThr={nt} noiseCond={nsc} doRefPfrh={drpf} doRefSeed={drsd} doSafetyMargin={mr} doPU={dp} doRingAverageEB={draeb} doRingAverageEE={draee} year={y} doDefaultECALtags={ddet} showerSigmaMult={shs} maxSigmaDist={md} maxEvents={n}'.format(jo=target_drivers[2], reco=dorecofile, miniaod=dominiaodfile, pfrhm=opt.pfrhmult, sm=opt.seedmult, nt=nthr, nsc=noisecnd, drpf=dorefpfrh, drsd=dorefseed, mr=dosafetymargin, dp=dopu, draeb=doringavgEB, draee=doringavgEE, y=opt.year, ddet=dodefaultecaltags, shs=opt.showersigmamult, md=opt.maxsigmadist, n=nevtsjob)
+  step3_cmsRun = 'cmsRun {jo} dorecofile={reco} dominiaodfile={miniaod} pfrhMultbelow2p5={pfrhmb} pfrhMultabove2p5={pfrhma} seedMultbelow2p5={smb} seedMultabove2p5={sma} nThr={nt} noiseCond={nsc} doRefPfrh={drpf} doRefSeed={drsd} doSafetyMargin={mr} doPU={dp} doRingAverageEB={draeb} doRingAverageEE={draee} year={y} doDefaultECALtags={ddet} showerSigmaMult={shs} maxSigmaDist={md} maxEvents={n}'.format(jo=target_drivers[2], reco=dorecofile, miniaod=dominiaodfile, pfrhmb=pfrhMultbelow2p5, pfrhma=pfrhMultabove2p5, smb=seedMultbelow2p5, sma=seedMultabove2p5, nt=nthr, nsc=noisecnd, drpf=dorefpfrh, drsd=dorefseed, mr=dosafetymargin, dp=dopu, draeb=doringavgEB, draee=doringavgEE, y=opt.year, ddet=dodefaultecaltags, shs=opt.showersigmamult, md=opt.maxsigmadist, n=nevtsjob)
   cmsRuns = [step1_cmsRun, step2_cmsRun, step3_cmsRun]
   cmsRuns_add = [step1_cmsRun_add, step2_cmsRun_add, '']
   if opt.ch == 'QCD':


### PR DESCRIPTION
@mgratti 

The main changes imported by the PR are:

- QCD production enabled:
    -> standalone step1 created (to respect the logic of having an individual step1 for the different cases)
    -> step3 modified: now can also produced miniaod 
    -> step4 created: miniaoadsim -> nanoaodsim
    At the level of the prodHelper: 
         -> --ch QCD to switch to QCD prod
         -> this will switch on automatically the --dominiaodfile and off --dorecofile
         -> will not run the dumper and run the step4 instead

- Handling of the safety margin: 
     -> the 10% safety margin on the values of the thresholds is now removed by default, and can be reactivated with --dosafetymargin

 - Specification of the year of the noise condition:
      -> now possible to produce sample with GT of year X and noise conditions of year Y
      -> for that, --noiseCond Y has to be added to the command line

- Now possible to produce reco samples with different sigma multiplicities below and above eta=2.5
      -> for that, use --pfrhmultbelow2p5 X --pfrhmultabove2p5 Y instead of --pfrhmult Z
      -> same for seeding
      -> always possibility to use --dopfrhmult --doseedmult if one wants same thresholds for all eta

